### PR TITLE
Implemented commands to prune old, deleted data

### DIFF
--- a/app/Console/Commands/AggregateCommand.php
+++ b/app/Console/Commands/AggregateCommand.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Exceptions\AggregatedCommandFailedException;
+use App\Exceptions\AggregatedCommandThrewException;
+use App\Exceptions\InvalidAggregatedCommandException;
+use Throwable;
+
+/**
+ * Abstract base class for a command that aggregates a number of other commands.
+ *
+ * Subclasses need only populate the $commands property with the commands to run. Only commands that don't take any
+ * arguments or options can (currently) be aggregated.
+ */
+abstract class AggregateCommand extends Command
+{
+    /**
+     * @var array Array of commands to execute. Can be:
+     * - string (just the command to execute, e.g. app:do-something)
+     * - associative array with "command" and optional "arguments" elements (e.g. ["command" => "app:do-something", "arguments" -> ["--opt1", "--opt2=foo",])
+     * - object with "command" and optionally "arguments" properties (e.g. new StdClass() { $command = "app:do-something"; $arguments = ["--opt1", "--opt2=foo",]; })
+     */
+    protected array $commands = [];
+
+    /**
+     * @var bool Set to true to abort on the first command that returns non-0.
+     */
+    protected bool $abortOnFail = true;
+
+    /**
+     * @return int
+     * @throws \App\Exceptions\AggregatedCommandFailedException
+     * @throws \App\Exceptions\AggregatedCommandThrewException
+     * @throws \App\Exceptions\InvalidAggregatedCommandException
+     */
+    public function handle(): int
+    {
+        $returnCode = 0;
+
+        foreach ($this->commands as $command) {
+            if (is_string($command)) {
+                $args = [];
+            } else if (is_array($command)) {
+                $args = $command["arguments"] ?? [];
+                $command = $command["command"];
+            } else if (is_object($command) && is_string($command->command ?? null)) {
+                $args = $command->arguments ?? [];
+                $command = $command->command;
+            } else {
+                throw new InvalidAggregatedCommandException("Invalid command in " . static::class, $command);
+            }
+
+            $this->line("Running ${command}");
+
+            try {
+                $returnCode = $this->call($command, $args) || $returnCode;
+            } catch (Throwable $e) {
+                throw new AggregatedCommandThrewException($command, $args, $e, "Command ${command} threw " . get_class($e) . ".");
+            }
+
+            if ($this->abortOnFail && 0 != $returnCode) {
+                throw new AggregatedCommandFailedException($command, $args, $returnCode, "Command ${command} failed with return code ${returnCode}.");
+            }
+        }
+
+        return $returnCode;
+    }
+}

--- a/app/Console/Commands/Command.php
+++ b/app/Console/Commands/Command.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Console\Commands;
+
+/**
+ * Abstract base class for Barley commands.
+ */
+abstract class Command extends \Illuminate\Console\Command
+{
+    /**
+     * Constant to return from handle() methods when the command was successful.
+     */
+    public const ExitOk = 0;
+}

--- a/app/Console/Commands/PruneAll.php
+++ b/app/Console/Commands/PruneAll.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Console\Commands;
+
+/**
+ * Command to prune all soft-deleted data from the database.
+ *
+ * This aggregates all the barley prune:barley-* commands. Each individual command has its own threshold for deciding
+ * how long ago a soft-delete occurred for it to qualify for pruning.
+ */
+class PruneAll extends AggregateCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'prune:barley-all';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command description';
+
+    /**
+     * The individual commands that do the pruning of specific models.
+     *
+     * @var array|string[]
+     */
+    protected array $commands = [
+        "prune:barley-users",
+        "prune:barley-barcodes",
+        "prune:barley-tags",
+        "prune:barley-shared-barcodes",
+    ];
+
+    protected bool $abortOnFail = false;
+}

--- a/app/Console/Commands/PruneBarcodes.php
+++ b/app/Console/Commands/PruneBarcodes.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Barcode;
+
+/**
+ * Command to prune soft-deleted records from the barcodes table.
+ *
+ * Barcodes that were soft-deleted more than 7 days ago will be pruned.
+ */
+class PruneBarcodes extends PruneCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'prune:barley-barcodes';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command description';
+
+    /**
+     * @var int|null The cutoff age, in days, for pruning soft-deletes.
+     */
+    protected ?int $age = 7;
+
+    /**
+     * @var string|null The model class for barcodes.
+     */
+    protected ?string $model = Barcode::class;
+}

--- a/app/Console/Commands/PruneCommand.php
+++ b/app/Console/Commands/PruneCommand.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Exceptions\InvalidPruneModelException;
+use App\Exceptions\MissingPruneModelException;
+use DateTime;
+use Exception;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Abstract base class for commands that prune soft-deleted records from the database.
+ */
+abstract class PruneCommand extends Command
+{
+    /**
+     * Return code indicating that the age specified as the threshold for pruning is not valid.
+     */
+    public const ErrInvalidAge = 1;
+
+    /**
+     * Return code indicating that the model class specified for pruning is not valid.
+     */
+    public const ErrInvalidModel = 2;
+
+    /**
+     * @var string|null Set this to the class name of the Eloquent model that is being pruned.
+     *
+     * Setting this to a valid model class will cause the default implementation of getQueryBuilder() to call query() on
+     * that model to get the base query to select the models to be pruned (an age constraint for deleted_at is added
+     * according to the returned value from getAge() in handle()). If you need finer control over the base query,
+     * reimplement getQueryBuilder() in your subclass.
+     */
+    protected ?string $model;
+
+    /**
+     * @var int|null The number of days of soft-deleted models to retain.
+     *
+     * Anything soft-deleted more than this many days ago will be deleted. If you need more control over the age than
+     * a fixed property value, don't set this property and reimplement getAge() instead.
+     */
+    protected ?int $age;
+
+    /**
+     * The age, in days, for which to retain soft-deleted models.
+     *
+     * Anything soft-deleted before this age that is selected by the base query will be pruned.
+     *
+     * @return int
+     */
+    public function getAge(): int
+    {
+        if (is_null($this->age)) {
+            throw new \RuntimeException("Base implementation of getAge() called with no defined age property.");
+        }
+
+        return $this->age;
+    }
+
+    /**
+     * Helper to get the base query for pruning.
+     *
+     * This is the query before the deleted_at constraint is added.
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     * @throws \App\Exceptions\InvalidPruneModelException
+     * @throws \App\Exceptions\MissingPruneModelException
+     */
+    protected function getQueryBuilder(): Builder
+    {
+        if (!$this->model) {
+            throw new MissingPruneModelException("Base implementation of getQueryBuilder() called with no defined model class.");
+        }
+
+        if (!is_subclass_of($this->model, Model::class)) {
+            throw new InvalidPruneModelException($this->model, "Defined model class is not a subclass of " . Model::class . ".");
+        }
+
+        return call_user_func([$this->model, "query"]);
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle(): int
+    {
+        try {
+            $age = $this->getAge();
+            $res = $this->getQueryBuilder()
+                ->where("deleted_at", "<", new DateTime("{$age} days ago"))
+                ->forceDelete();
+        } catch (MissingPruneModelException $e) {
+            $this->error("Missing model class when pruning in command " . static::class . ".");
+            return self::ErrInvalidModel;
+        } catch (InvalidPruneModelException $e) {
+            $this->error("Invalid model class '{$e->getModel()}' when pruning in command " . static::class . ".");
+            return self::ErrInvalidModel;
+        } catch (Exception) {
+            $this->error("The age {$age} did not produce a valid cutoff date.");
+            return self::ErrInvalidAge;
+        }
+
+        $this->line("pruned {$res} record(s).");
+        return self::ExitOk;
+    }
+
+}

--- a/app/Console/Commands/PruneSharedBarcodes.php
+++ b/app/Console/Commands/PruneSharedBarcodes.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\SharedBarcode;
+
+/**
+ * Command to prune old soft-deleted records from the shared_barcodes table.
+ *
+ * Shared barcodes that were soft-deleted more than 7 days ago are pruned.
+ */
+class PruneSharedBarcodes extends PruneCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'prune:barley-shared-barcodes';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command description';
+
+    /**
+     * @var string|null The model class for shared barcodes.
+     */
+    protected ?string $model = SharedBarcode::class;
+
+    /**
+     * @var int|null The cutoff age, in days, for pruning soft-deletes.
+     */
+    protected ?int $age = 7;
+}

--- a/app/Console/Commands/PruneTags.php
+++ b/app/Console/Commands/PruneTags.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Tag;
+
+/**
+ * Command to prune old soft-deleted records from the tags table.
+ *
+ * Tags that were soft-deleted more than 7 days ago are pruned.
+ */
+class PruneTags extends PruneCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'prune:barley-tags';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command description';
+
+    /**
+     * @var string|null The model class for tags.
+     */
+    protected ?string $model = Tag::class;
+
+    /**
+     * @var int|null The cutoff age, in days, for pruning soft-deletes.
+     */
+    protected ?int $age = 7;
+}

--- a/app/Console/Commands/PruneUsers.php
+++ b/app/Console/Commands/PruneUsers.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+
+/**
+ * Command to prune soft-deleted users from the database.
+ *
+ * Users that were soft-deleted more than 28 days ago are pruned.
+ */
+class PruneUsers extends PruneCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = "prune:barley-users";
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = "Command description";
+
+    /**
+     * @var string|null Prune User models.
+     */
+    protected ?string $model = User::class;
+
+    /**
+     * @var int|null Prune models soft-deleted more than 28 days ago.
+     */
+    protected ?int $age = 28;
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -15,7 +15,8 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        // $schedule->command('inspire')->hourly();
+        // every hour, prune all soft-deleted data that has reached its expiry threshold
+        $schedule->command("prune:barley-all")->hourly();
     }
 
     /**

--- a/app/Exceptions/AggregatedCommandException.php
+++ b/app/Exceptions/AggregatedCommandException.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Exceptions;
+
+use JetBrains\PhpStorm\Pure;
+use Throwable;
+
+/**
+ * Abstract base class for exceptions thrown during execution of an AggregateCommand.
+ */
+abstract class AggregatedCommandException extends \Exception
+{
+    /**
+     * @var string The command that was aggregated that triggered the exception.
+     */
+    private string $m_command;
+
+    /**
+     * @var array|null The args to the command that was aggregated that triggered the exception.
+     *
+     * Will be null if there were no arguments.
+     */
+    private ?array $m_args;
+
+    /**
+     * @param string $command The command that threw.
+     * @param array|null $args The args to the command that threw.
+     * @param string $message An optional message indicating what happened. Default is an empty string.
+     * @param int $code An optional error code. Default is 0.
+     * @param \Throwable | null $previous An optional previous exception, if one exists.
+     *
+     */
+    #[Pure] public function __construct(string $command, ?array $args, string $message = "", int $code = 0, ?Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+        $this->m_command = $command;
+        $this->m_args = $args;
+    }
+
+    /**
+     * @return string The command that threw.
+     */
+    public function getCommand(): string
+    {
+        return $this->m_command;
+    }
+
+    /**
+     * @return array|null The args for the command that threw.
+     */
+    public function getArguments(): ?array
+    {
+        return $this->m_args;
+    }
+
+}

--- a/app/Exceptions/AggregatedCommandFailedException.php
+++ b/app/Exceptions/AggregatedCommandFailedException.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Exceptions;
+
+use Throwable;
+
+/**
+ * Exception thrown when an aggregated command fails and the AggregateCommand is set to abort on failure.
+ */
+class AggregatedCommandFailedException extends AggregatedCommandException
+{
+    /**
+     * @var int The return code of the command that failed.
+     */
+    private int $m_returnCode;
+
+    /**
+     * @param int $returnCode
+     * @param string $message
+     * @param int $code
+     * @param \Throwable|null $previous
+     */
+    public function __construct(string $command, ?array $args, int $returnCode, string $message = "", int $code = 0, ?Throwable $previous = null)
+    {
+        parent::__construct($command, $args, $message, $code, $previous);
+        $this->m_returnCode = $returnCode;
+    }
+
+    /**
+     * @return int The return code of the command that failed.
+     */
+    public function getReturnCode(): int
+    {
+        return $this->m_returnCode;
+    }
+}

--- a/app/Exceptions/AggregatedCommandThrewException.php
+++ b/app/Exceptions/AggregatedCommandThrewException.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Exceptions;
+
+use JetBrains\PhpStorm\Pure;
+use Throwable;
+
+/**
+ * Exception thrown when an AggregateCommand encounters a command that throws an exception.
+ */
+class AggregatedCommandThrewException extends AggregatedCommandException
+{
+    /**
+     * @param string $command The command that threw.
+     * @param array|null $args The args to the command that threw.
+     * @param \Throwable $thrownException The exception that the aggregated command threw.
+     * @param string $message An optional message indicating what happened. Default is an empty string.
+     * @param int $code An optional error code. Default is 0.
+     */
+    #[Pure] public function __construct(string $command, ?array $args, Throwable $thrownException, string $message = "", int $code = 0) {
+        parent::__construct($command, $args, $message, $code, $thrownException);
+    }
+
+    /**
+     * @return \Throwable The Throwable thrown by the aggregated command.
+     */
+    #[Pure] public function getThrowable(): Throwable
+    {
+        return $this->getPrevious();
+    }
+}

--- a/app/Exceptions/InvalidAggregatedCommandException.php
+++ b/app/Exceptions/InvalidAggregatedCommandException.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Exceptions;
+
+use Stringable;
+use Throwable;
+
+/**
+ * Exception thrown when an AggregateCommand is given an invalid command to run.
+ */
+class InvalidAggregatedCommandException extends \Exception
+{
+    public mixed $command;
+
+    /**
+     * Initialise a new exception instance.
+     *
+     * @param string $message The message indicating the problem.
+     * @param mixed|null $command The command that was found to be invalid.
+     * @param int $code The exception code.
+     * @param \Throwable|null $previous The previously-thrown exception, if any.
+     */
+    public function __construct(string $message, mixed $command = null, int $code = 0, ?Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+        $this->command = $command;
+    }
+
+    /**
+     * Get a stringified representation of the invalid command.
+     *
+     * @return string
+     */
+    public function getCommandString(): string
+    {
+        return match (gettype($this->command)) {
+            "string" => $this->command,
+            "integer" | "double" => "[numeric] " . $this->command,
+            "boolean" => "[boolean] " . ($this->command ? "true" : "false") . "]",
+            "array" => "[array]",
+            "object" => ($this->command instanceof Stringable ? (string) $this->command : "[" . get_class($this->command) . " object]"),
+            "NULL" => "[null]",
+            default => "[unknown type]"
+        };
+    }
+}

--- a/app/Exceptions/InvalidPruneModelException.php
+++ b/app/Exceptions/InvalidPruneModelException.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Exceptions;
+
+use Throwable;
+
+/**
+ * Exception thrown when a model specified in a PruneCommand subclass is not a valid Model class.
+ */
+class InvalidPruneModelException extends PruneCommandException
+{
+    private string $m_model;
+
+    /**
+     * @param string $model The model class name that was found to be invalid.
+     * @param string $message
+     * @param int $code
+     * @param Throwable|null $previous
+     */
+    public function __construct(string $model, string $message = "", int $code = 0, ?Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+        $this->m_model = $model;
+    }
+
+    /**
+     * @return string The model class name that was found to be invalid.
+     */
+    public function getModel(): string
+    {
+        return $this->m_model;
+    }
+}

--- a/app/Exceptions/MissingPruneModelException.php
+++ b/app/Exceptions/MissingPruneModelException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Exceptions;
+
+/**
+ * Exception thrown when no model has been specified in a PruneCommand subclass..
+ */
+class MissingPruneModelException extends PruneCommandException
+{}

--- a/app/Exceptions/PruneCommandException.php
+++ b/app/Exceptions/PruneCommandException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Exceptions;
+
+/**
+ * Abstract base class for all exceptions thrown by PruneCommands.
+ */
+abstract class PruneCommandException extends \Exception
+{}

--- a/app/Models/Barcode.php
+++ b/app/Models/Barcode.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+
+/**
+ * Model representing a barcode stored for a user in the database.
+ *
+ * @property int id
+ * @property string name
+ * @property string data
+ * @property string generator
+ * @property DateTime created_at
+ * @property DateTime updated_at
+ * @property ?DateTime deleted_at
+ */
+class Barcode extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        "name",
+        "data",
+        "generator",
+    ];
+
+    /**
+     * The tags for the barcode.
+     */
+    public function tags(): HasManyThrough
+    {
+        return $this->hasManyThrough(Tag::class, BarcodeTag::class, "barcode_id", "tag_id");
+    }
+}

--- a/app/Models/BarcodeTag.php
+++ b/app/Models/BarcodeTag.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+/**
+ * Model representing a link record joining barcode to tags stored for a user in the database.
+ *
+ * @property int barcode_id
+ * @property int tag_id
+ * @property DateTime created_at
+ * @property DateTime updated_at
+ * @property ?DateTime deleted_at
+ */
+class BarcodeTag extends Model
+{
+    use HasFactory;
+
+    /**
+     * The relationship between BarcodeTags and Barcodes.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     */
+    public function barcode(): HasOne
+    {
+        return $this->hasOne(Barcode::class);
+    }
+
+    /**
+     * The relationship between BarcodeTags and Tags.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     */
+    public function tag(): HasOne
+    {
+        return $this->hasOne(Tag::class);
+    }
+}

--- a/app/Models/SharedBarcode.php
+++ b/app/Models/SharedBarcode.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Model class for records in the shared_barcodes table.
+ *
+ * @property int $original_barcode_id
+ * @property string $data
+ * @property string $generator
+ * @property DateTime $expires_at
+ * @property DateTime created_at
+ * @property DateTime updated_at
+ * @property ?DateTime deleted_at
+ */
+class SharedBarcode extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        "data",
+        "generator",
+        "expires_at",
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        "expires_at" => "datetime",
+    ];
+
+    /**
+     * Determine whether the barcode was shared from an original stored barcode for a user.
+     *
+     * @return bool true if the shared barcode links to an original barcode stored by a user, false if not.
+     */
+    protected function hasOriginal(): bool
+    {
+        return null !== $this->original_barcode_id;
+    }
+}

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Model class for records in the tags table.
+ *
+ * @property string $tag
+ * @property ?DateTime $archived_at
+ * @property DateTime created_at
+ * @property DateTime updated_at
+ * @property ?DateTime deleted_at
+ */
+class Tag extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        "tag",
+        "archived_at",
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        "archived_at" => "datetime",
+    ];
+
+    /**
+     * Determine whether the tag has been archived.
+     *
+     * @return bool true if the tag is archived, false otherwise.
+     */
+    public function isArchived(): bool
+    {
+        return null !== $this->archived_at;
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,10 +4,25 @@ namespace App\Models;
 
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
 
+/**
+ * Model class for records in the users table.
+ *
+ * @property int id
+ * @property string name
+ * @property string username
+ * @property string email
+ * @property string password
+ * @property string remember_token
+ * @property ?DateTime email_verified_at
+ * @property DateTime created_at
+ * @property DateTime updated_at
+ * @property ?DateTime deleted_at
+ */
 class User extends Authenticatable
 {
     use HasApiTokens, HasFactory, Notifiable;
@@ -18,9 +33,10 @@ class User extends Authenticatable
      * @var array<int, string>
      */
     protected $fillable = [
-        'name',
-        'email',
-        'password',
+        "name",
+        "username",
+        "email",
+        "password",
     ];
 
     /**
@@ -29,8 +45,8 @@ class User extends Authenticatable
      * @var array<int, string>
      */
     protected $hidden = [
-        'password',
-        'remember_token',
+        "password",
+        "remember_token",
     ];
 
     /**
@@ -39,6 +55,26 @@ class User extends Authenticatable
      * @var array<string, string>
      */
     protected $casts = [
-        'email_verified_at' => 'datetime',
+        "email_verified_at" => "datetime",
     ];
+
+    /**
+     * The user's stored barcodes.
+     *
+     * @return HasMany
+     */
+    public function barcodes(): HasMany
+    {
+        return $this->hasMany(Barcode::class, "user_id");
+    }
+
+    /**
+     * The user's tags.
+     *
+     * @return HasMany
+     */
+    public function tags(): HasMany
+    {
+        return $this->hasMany(Tag::class, "user_id");
+    }
 }

--- a/docker/local/docker-compose.yml
+++ b/docker/local/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - ../../:/usr/share/nginx/html
       - ./logs:/var/log/barley
       - ./etc/profile.d/xdebug-php.sh:/etc/profile.d/xdebug-php.sh
+      - ./etc/crontabs:/etc/crontabs
     environment:
       - PHP_IDE_CONFIG=serverName=Docker
       - ENV=/etc/profile

--- a/docker/local/etc/crontabs/www-data
+++ b/docker/local/etc/crontabs/www-data
@@ -1,0 +1,3 @@
+SHELL=/bin/sh
+PATH=/usr/local/sbin:/usr/local/bin
+*/5 * * * * cd /usr/share/nginx/html && php artisan schedule:run >/dev/null 2>&1

--- a/docker/local/scripts/start-app-cron.sh
+++ b/docker/local/scripts/start-app-cron.sh
@@ -1,0 +1,2 @@
+#! /usr/bin/env bash
+docker exec barley-web-php81-1 crond

--- a/docker/local/scripts/stop-app-cron.sh
+++ b/docker/local/scripts/stop-app-cron.sh
@@ -1,0 +1,2 @@
+#! /usr/bin/env bash
+docker exec barley-web-php81-1 pkill crond


### PR DESCRIPTION
- added abstract base class for all barley commands
- added AggregateCommand class to enable easy aggregation of multiple commands in a single command
- added exception classes for aggregating commands
- added model classes for all entities
- added simple base class for commands that prune tables
- added exception classes for pruning commands
- added commands to prune:
  - barcodes
  - users
  - shared_barcodes
  - tags
- added aggregating command to run all prunes with a single command
- added scheduled task to run prune:barley-all hourly
- added crontab to local docker PHP container to run the laravel scheduled tasks every 5 minutes
- added support scripts to start/stop the cron daemon on the PHP docker container