### PR TITLE
Updated Bitmap output formats

### DIFF
--- a/app/Util/Bitmap.php
+++ b/app/Util/Bitmap.php
@@ -92,7 +92,6 @@ class Bitmap
             BitmapOutputFormat::Jpeg => IMG_JPEG,
             BitmapOutputFormat::Gif => IMG_GIF,
             BitmapOutputFormat::Bmp => IMG_BMP,
-            BitmapOutputFormat::Xpm => IMG_XPM,
             BitmapOutputFormat::Webp => IMG_WEBP,
         });
     }
@@ -112,6 +111,8 @@ class Bitmap
             BitmapOutputFormat::Png => imagepng($this->m_image),
             BitmapOutputFormat::Jpeg => imagejpeg($this->m_image),
             BitmapOutputFormat::Bmp => imagebmp($this->m_image),
+            BitmapOutputFormat::Gif => imagegif($this->m_image),
+            BitmapOutputFormat::Webp => imagewebp($this->m_image),
         };
 
         $data = ob_get_contents();

--- a/app/Util/BitmapOutputFormat.php
+++ b/app/Util/BitmapOutputFormat.php
@@ -2,12 +2,17 @@
 
 namespace App\Util;
 
+/**
+ * Enumeration of possible output formats for Bitmap objects.
+ *
+ * Bitmap implementations need not support all formats, but should try to support as many as possible. As a bare
+ * minimum, PNG and JPEG are recommended.
+ */
 enum BitmapOutputFormat
 {
     case Png;
     case Jpeg;
     case Gif;
     case Bmp;
-    case Xpm;
     case Webp;
 }

--- a/app/Util/BitmapResponse.php
+++ b/app/Util/BitmapResponse.php
@@ -19,6 +19,7 @@ class BitmapResponse extends Response
             BitmapOutputFormat::Jpeg => "image/jpeg",
             BitmapOutputFormat::Bmp => "image/bmp",
             BitmapOutputFormat::Gif => "image/gif",
+            BitmapOutputFormat::Webp => "image/webp",
         }]);
     }
 }


### PR DESCRIPTION
- removed XBM as an output format (big security issues)
- added missing output formats to Bitmap::data()
- added missing output format MIME types to BitmapResponse